### PR TITLE
Avoiding "local variable'i_val' referenced before assignment"

### DIFF
--- a/IS-Net/train_valid_inference_main.py
+++ b/IS-Net/train_valid_inference_main.py
@@ -198,6 +198,8 @@ def valid_gt_encoder(net, valid_dataloaders, valid_datasets, hypar, epoch=0):
         MAE = np.zeros((val_num))
 
         val_cnt = 0.0
+        i_val = None
+
         for i_val, data_val in enumerate(valid_dataloader):
 
             # imidx_val, inputs_val, labels_val, shapes_val = data_val['imidx'], data_val['image'], data_val['label'], data_val['shape']


### PR DESCRIPTION
Avoids errors when there are zero data sets, or when there is a mistake in the input path of the data set and the variable `i_val` is not predefined.

- Error sample
  ```bash
    File "/home/xxxx/git/DIS/IS-Net/train_valid_inference_main.py", line 591, in valid
      return tmp_f1, tmp_mae, val_loss, tar_loss, i_val, tmp_time
  UnboundLocalError: local variable 'i_val' referenced before assignment
  ```